### PR TITLE
Removed quotes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Stripe.Mixfile do
       elixir: "~> 1.1",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test,


### PR DESCRIPTION
removed quotes to suppress warning
```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
```